### PR TITLE
Fix for submeshes not being exported properly

### DIFF
--- a/Editor/MeshLODExporter.cs
+++ b/Editor/MeshLODExporter.cs
@@ -70,7 +70,7 @@ namespace sc.meshlod2fbx.editor
 
                 renderer.sharedMaterials = materials;
 
-                float t = 1f-((float)i / (lodMeshes.Length));
+                float t = 1f-((float)(i+1) / (lodMeshes.Length+1));
                 m_lods[i] = new LOD(t, new Renderer[] { renderer });
             }
             

--- a/Editor/MeshLODExporter.cs
+++ b/Editor/MeshLODExporter.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using UnityEditor;
 using UnityEngine;
+using UnityEngine.Rendering;
 using Object = UnityEngine.Object;
 
 namespace sc.meshlod2fbx.editor
@@ -19,6 +20,7 @@ namespace sc.meshlod2fbx.editor
         
             //Safeguard against error: The Mesh LOD index (#) must be less than the lodCount value (#)
             lodCount = Mathf.Min(lodCount, meshLOD.lodCount);
+            int subMeshCount = meshLOD.subMeshCount;
             
             //Extract triangles for new individual meshes
             Mesh[] lods = new Mesh[lodCount];
@@ -29,7 +31,6 @@ namespace sc.meshlod2fbx.editor
                 //Copy vertices, uvs, normals, etc...
                 EditorUtility.CopySerialized(meshLOD, lodMesh);
 
-                int subMeshCount = meshLOD.subMeshCount;
                 for (int j = 0; j < subMeshCount; j++)
                 {
                     int[] triangles = meshLOD.GetTriangles(j, i, false);
@@ -50,7 +51,7 @@ namespace sc.meshlod2fbx.editor
             #endif
         }
 
-        public static GameObject CreateObjects(Mesh[] lodMeshes)
+        public static GameObject CreateObjects(Mesh[] lodMeshes, Material[] materials)
         {
             GameObject root = new GameObject();
             
@@ -66,6 +67,8 @@ namespace sc.meshlod2fbx.editor
                 filter.sharedMesh = lodMeshes[i];
                 
                 MeshRenderer renderer = obj.GetComponent<MeshRenderer>();
+
+                renderer.sharedMaterials = materials;
 
                 float t = 1f-((float)i / (lodMeshes.Length));
                 m_lods[i] = new LOD(t, new Renderer[] { renderer });

--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,8 @@
+﻿1.0.1
+
+Fixed:
+- Submeshes not being exported properly
+- LOD0 range of exported model being 0 in the LOD Group component
+
+1.0.0
+- Initial release

--- a/changelog.md.meta
+++ b/changelog.md.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: d4daf180808a42ea9f2e9488daf0da0b
+timeCreated: 1755702722

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "staggartcreations.meshlod2fbx",
   "displayName": "MeshLOD to FBX Exporter",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "unity": "6000.2",
   "description": "Generates LODs using MeshLOD and exports them to an FBX file",
   "keywords": [


### PR DESCRIPTION
The temporary GameObject requires a number of (unique) materials in order for the FBX Exporter to also export the submeshes.